### PR TITLE
implement .env files support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "tonicforhealth/behat-parallel-scenario": "1.0.7",
     "brianium/paratest": "0.13.2",
     "squizlabs/php_codesniffer": "2.0.0",
-    "peekmo/jsonpath": "1.1.0"
+    "peekmo/jsonpath": "1.1.0",
+    "vlucas/phpdotenv": "2.4.0"
     },
   "autoload": {
     "psr-4": {

--- a/src/Athena.php
+++ b/src/Athena.php
@@ -74,6 +74,8 @@ class Athena
                 $settings->set('browser', ATHENA_BROWSER);
             }
 
+            $settings->loadDotEnv(getcwd());
+
             static::$instance = new static($settings, new EventDispatcher());
         }
 

--- a/src/Configuration/Settings.php
+++ b/src/Configuration/Settings.php
@@ -16,6 +16,18 @@ class Settings
     }
 
     /**
+     * Load environment variables from .env file
+     *
+     * @param string $path
+     * @param string $file
+     */
+    public function loadDotEnv($path, $file = '.env')
+    {
+        $dotEnv = new Dotenv($path, $file);
+        $dotEnv->load();
+    }
+
+    /**
      * Returns the setting with the given name.
      *
      * @param $name


### PR DESCRIPTION
This PR will allow the creation of a .env file inside the tests root directory from which environment variables will be loaded and used in athena's json configuration file

**.env**
```sh
ATHENA_WEBSERVER_IP=172.17.0.1
```

**athena.json**
```sh
   "remapHosts": {
      "myproject.com" : "ENV[ATHENA_WEBSERVER_IP]"
    },
```